### PR TITLE
fix(added mocks to the tests)

### DIFF
--- a/tests.py
+++ b/tests.py
@@ -1,5 +1,6 @@
 import urllib.request
 import unittest
+import unittest.mock
 from threading import Thread
 
 import simplebin
@@ -29,16 +30,23 @@ class TestSimpleBin(unittest.TestCase):
 
 
     def test_get_snippet(self):
+        import unittest.mock
+        snippet = simplebin.Snippet("iexist", "Hello world")
+
         """ Accessing a snippet that exist show the valid code """
-        with urlopen('/iexist') as res:
-            self.assertEqual(res.status, 200)
-            self.assertEqual(res.read().decode(), "Hello world")
+        with unittest.mock.patch('simplebin.Snippet') as mock_snippet:
+            mock_snippet.get_by_name.return_value = snippet
+            with urlopen('/iexist') as res:
+                self.assertEqual(res.status, 200)
+                self.assertEqual(res.read().decode(), "Hello world")
 
 
     def test_missing_snippet(self):
         """ Accessing a snippet that does not exist fails with a 404 """
-        with urlopen('/idontexist') as res:
-            self.assertEqual(res.status, 404)
+        with unittest.mock.patch('simplebin.Snippet') as mock_snippet:
+            mock_snippet.get_by_name.side_effect = ValueError(404)
+            with urlopen('/idontexist') as res:
+                self.assertEqual(res.status, 404)
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
The tests were trying to check if a snippet was existing, but it wasn't so it returned an error to the test. The same happened when it checked if the snippet didn't exist, because it actually existed.

In order to fix that, I've added two mocks to the tests so we do not modify the production storage and the tests do actually pass.